### PR TITLE
implement Reset()

### DIFF
--- a/shared_error.go
+++ b/shared_error.go
@@ -30,6 +30,11 @@ func (s *SharedError) Error() string {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	return s.string()
+}
+
+// assumes that s is already locked
+func (s *SharedError) string() string {
 	if len(s.err) == 0 {
 		return ""
 	}
@@ -73,6 +78,25 @@ func (s *SharedError) Store(err error) {
 	defer s.lock.Unlock()
 
 	s.err = append(s.err, err)
+}
+
+// Return any error and reset the error if it was triggered.
+func (s *SharedError) Reset() error {
+	if s == nil {
+		return nil
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	err := s.string()
+	s.err = nil
+
+	if err == "" {
+		return nil
+	}
+
+	return errors.New(err)
 }
 
 // Store stores an error condition in SharedError.

--- a/shared_error_test.go
+++ b/shared_error_test.go
@@ -123,3 +123,25 @@ func TestSharedErrorIsAll(t *testing.T) {
 		t.Errorf("expected not all errors match on target error, got all matches")
 	}
 }
+
+func TestReset(t *testing.T) {
+	var sharedErr = sharederror.NewSharedError()
+
+	err := sharedErr.Reset()
+	if err != nil {
+		t.Errorf("incorrect result")
+	}
+
+	t.Log("store error")
+	sharedErr.Store(fmt.Errorf("some error"))
+
+	err = sharedErr.Reset()
+	if err == nil {
+		t.Errorf("incorrect result")
+	}
+
+	err = sharedErr.Reset()
+	if err != nil {
+		t.Errorf("incorrect result")
+	}
+}


### PR DESCRIPTION
`Reset()` returns the error, if there is an error (`nil` otherwise) and resets the `SharedError` to a non-error state.
